### PR TITLE
`commands.bot` to `commands.Bot`

### DIFF
--- a/dinteractions_Paginator/_Paginator.py
+++ b/dinteractions_Paginator/_Paginator.py
@@ -16,7 +16,7 @@ from discord_slash.utils.manage_components import (
 
 
 async def Paginator(
-    bot: commands.bot,
+    bot: commands.Bot,
     ctx: SlashContext,
     pages: List[discord.Embed],
     content: Optional[str] = None,


### PR DESCRIPTION
Line 19 had `bot: commands.bot` instead of `bot: commands.Bot`, I'm 99% sure it is supposed to be `commands.Bot`